### PR TITLE
LAB-68 add paging to GitHub config

### DIFF
--- a/Github/SourceJSONConfig.json
+++ b/Github/SourceJSONConfig.json
@@ -2,6 +2,15 @@
   "Services": [
     {
       "Url": "https://api.github.com/",
+      "Paging": {
+        "OffsetStart": 0,
+        "PageSize": 30,
+        "OffsetType": "page",
+        "Parameters": {
+          "Offset": "page",
+          "limit": "per_page"
+        }
+      },
       "Endpoints": [
         {
           "Headers": {

--- a/Github/SourceJSONConfig.json
+++ b/Github/SourceJSONConfig.json
@@ -4,7 +4,7 @@
       "Url": "https://api.github.com/",
       "Paging": {
         "OffsetStart": 0,
-        "PageSize": 30,
+        "PageSize": 100,
         "OffsetType": "page",
         "Parameters": {
           "Offset": "page",


### PR DESCRIPTION
Github limits the request to 30 items by default. 
And without Paging, you will get only the first 30.

The limit per page for Github is 100. We should set it at 100 so we do less requests overall. 