### PR TITLE
Doc 10366 adding links to various resources

### DIFF
--- a/APP Direct/README.md
+++ b/APP Direct/README.md
@@ -14,7 +14,7 @@ To fully understand how to use this example, you must:
 2. Make sure you've changed all placeholders in the configuration with your own values.
 3. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 4. [Write an indexing pipeline extension](https://docs.coveo.com/en/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/APP%20Direct/IPE.py).
-5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+5. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Limitation
 Permissions can't be indexed.

--- a/APP Direct/README.md
+++ b/APP Direct/README.md
@@ -13,7 +13,7 @@ To fully understand how to use this example, you must:
 1. [Create and configure a Generic REST API source](https://docs.coveo.com/en/1896/) using the example in [SourceJSONConfig.json](https://github.com/coveooss/connectivity-library/blob/master/APP%20Direct/SourceJSONConfig.json). This JSON configuration contains one Endpoint, which gets a list of all products, and one Subquery, which gets more details on the product. Adjust it to your own needs.
 2. Make sure you've changed all placeholders in the configuration with your own values.
 3. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-4. [Add the indexing pipeline extension provided in this folder (IPE.py file) to your Coveo organization](https://docs.coveo.com/en/1645/).
+4. [Write an indexing pipeline extension](https://docs.coveo.com/en/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/APP%20Direct/IPE.py).
 5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Limitation

--- a/APP Direct/README.md
+++ b/APP Direct/README.md
@@ -13,6 +13,8 @@ To fully understand how to use this example, you must:
 1. [Create and configure a Generic REST API source](https://docs.coveo.com/en/1896/) using the example in [SourceJSONConfig.json](https://github.com/coveooss/connectivity-library/blob/master/APP%20Direct/SourceJSONConfig.json). This JSON configuration contains one Endpoint, which gets a list of all products, and one Subquery, which gets more details on the product. Adjust it to your own needs.
 2. Make sure you've changed all placeholders in the configuration with your own values.
 3. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+4. [Add the indexing pipeline extension provided in this folder (IPE.py file) to your Coveo organization](https://docs.coveo.com/en/1645/).
+5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Limitation
 Permissions can't be indexed.

--- a/APP Direct/README.md
+++ b/APP Direct/README.md
@@ -16,3 +16,6 @@ To fully understand how to use this example, you must:
 
 ## Limitation
 Permissions can't be indexed.
+
+## Reference
+[AppDirect API documentation](https://help.appdirect.com/develop/useAppDirectAPI.html)

--- a/Azure Active Directory/README.md
+++ b/Azure Active Directory/README.md
@@ -17,7 +17,7 @@ To fully understand how to use this example, you must:
 5. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Azure%20Active%20Directory/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses OAuth 2.0 authentication. It also contains one Endpoint, which gets a list of the users (with Query Parameters to index the users' information), and one Subquery, which gets the user's photos. Adjust it to your own needs.
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-9. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+9. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Limitation
 Content [refresh](https://docs.coveo.com/en/2039/#refresh) isn't possible since the link for the next page is an URL rather than a date.

--- a/Azure Active Directory/README.md
+++ b/Azure Active Directory/README.md
@@ -17,6 +17,7 @@ To fully understand how to use this example, you must:
 5. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Azure%20Active%20Directory/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses OAuth 2.0 authentication. It also contains one Endpoint, which gets a list of the users (with Query Parameters to index the users' information), and one Subquery, which gets the user's photos. Adjust it to your own needs.
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+9. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Limitation
 Content [refresh](https://docs.coveo.com/en/2039/#refresh) isn't possible since the link for the next page is an URL rather than a date.

--- a/Azure Active Directory/README.md
+++ b/Azure Active Directory/README.md
@@ -20,3 +20,6 @@ To fully understand how to use this example, you must:
 
 ## Limitation
 Content [refresh](https://docs.coveo.com/en/2039/#refresh) isn't possible since the link for the next page is an URL rather than a date.
+
+## Reference
+[Azure Active Directory API documentation](https://docs.microsoft.com/en-us/graph/use-the-api)

--- a/Azure DevOps/README.md
+++ b/Azure DevOps/README.md
@@ -15,6 +15,7 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Azure%20DevOps/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses a forced basic authentication. It also contains one endpoint and multiple nested subitems. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Reference
 [Azure DevOps Services REST API Reference](https://docs.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-rest-7.1)

--- a/Azure DevOps/README.md
+++ b/Azure DevOps/README.md
@@ -16,5 +16,5 @@ To fully understand how to use this example, you must:
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 
-## Further Reading
-[Azure DevOps Services REST API Reference](https://docs.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-server-rest-5.0)
+## Reference
+[Azure DevOps Services REST API Reference](https://docs.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-rest-7.1)

--- a/Azure DevOps/README.md
+++ b/Azure DevOps/README.md
@@ -15,7 +15,7 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Azure%20DevOps/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses a forced basic authentication. It also contains one endpoint and multiple nested subitems. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-6. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+6. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Azure DevOps Services REST API Reference](https://docs.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-rest-7.1)

--- a/ClickHelp/README.md
+++ b/ClickHelp/README.md
@@ -14,6 +14,7 @@ To fully understand how to use this example, you must:
 2. [Create a Generic REST API](https://docs.coveo.com/en/1896/) source and, in the **Authorization** section, fill in you username and the API key obtained in step 1. as the password.
 3. Use the example in [`SourceJSONConfig.json`](SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs. ClickHelp maintains a parent/child relationship between Project and Articles objects, this leads to a single endpoint to index projects along with SubItem queries to indexed the related Articles objects.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Reference
 [ClickHelp API documentation](https://clickhelp.com/software-documentation-tool/user-manual/clickhelp-api.html)

--- a/ClickHelp/README.md
+++ b/ClickHelp/README.md
@@ -14,7 +14,7 @@ To fully understand how to use this example, you must:
 2. [Create a Generic REST API](https://docs.coveo.com/en/1896/) source and, in the **Authorization** section, fill in you username and the API key obtained in step 1. as the password.
 3. Use the example in [`SourceJSONConfig.json`](SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs. ClickHelp maintains a parent/child relationship between Project and Articles objects, this leads to a single endpoint to index projects along with SubItem queries to indexed the related Articles objects.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+5. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [ClickHelp API documentation](https://clickhelp.com/software-documentation-tool/user-manual/clickhelp-api.html)

--- a/ClickHelp/README.md
+++ b/ClickHelp/README.md
@@ -14,3 +14,6 @@ To fully understand how to use this example, you must:
 2. [Create a Generic REST API](https://docs.coveo.com/en/1896/) source and, in the **Authorization** section, fill in you username and the API key obtained in step 1. as the password.
 3. Use the example in [`SourceJSONConfig.json`](SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs. ClickHelp maintains a parent/child relationship between Project and Articles objects, this leads to a single endpoint to index projects along with SubItem queries to indexed the related Articles objects.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[ClickHelp API documentation](https://clickhelp.com/software-documentation-tool/user-manual/clickhelp-api.html)

--- a/Contentful/readme.md
+++ b/Contentful/readme.md
@@ -35,6 +35,7 @@ Add in the parameter section (normally the parameter is already there):
 The above will add a `50 seconds` wait time when a `HTTP 429` code is received.
 
 7. [Create the appropriate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+8. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 
 ## Content indexed

--- a/Contentful/readme.md
+++ b/Contentful/readme.md
@@ -56,14 +56,11 @@ The following custom fields must be created:
 ## Security indexed
 All content is public
 
-
-
 ## Reference
-https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/assets/assets-collection
-
-https://www.contentful.com/developers/docs/references/content-management-api/#/introduction/authentication
-
-
+- [Contentful API documentation](https://www.contentful.com/developers/docs/)
+- [Contentful assets collection](
+https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/assets/assets-collection)
+- [Contentful authentication](https://www.contentful.com/developers/docs/references/content-management-api/#/introduction/authentication)
 
 ## Version
 1.0 Dec 2021, Wim Nijmeijer

--- a/Contentful/readme.md
+++ b/Contentful/readme.md
@@ -35,7 +35,7 @@ Add in the parameter section (normally the parameter is already there):
 The above will add a `50 seconds` wait time when a `HTTP 429` code is received.
 
 7. [Create the appropriate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-8. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+8. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 
 ## Content indexed

--- a/Cornerstone/README.md
+++ b/Cornerstone/README.md
@@ -23,7 +23,7 @@ To fully understand how to use this example, you must:
     * You can find the list of available parameters on an endpoint information page such as [this one](https://apiexplorer.csod.com/apiconnectorweb/apiexplorer#/apidoc/59aa5211-b2c9-45af-97b1-0c0902dc4060).
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-9. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+9. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Cornerstone API documentation](https://apiexplorer.csod.com/apiconnectorweb/apiexplorer#/info)

--- a/Cornerstone/README.md
+++ b/Cornerstone/README.md
@@ -23,6 +23,7 @@ To fully understand how to use this example, you must:
     * You can find the list of available parameters on an endpoint information page such as [this one](https://apiexplorer.csod.com/apiconnectorweb/apiexplorer#/apidoc/59aa5211-b2c9-45af-97b1-0c0902dc4060).
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+9. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Reference
 [Cornerstone API documentation](https://apiexplorer.csod.com/apiconnectorweb/apiexplorer#/info)

--- a/Cornerstone/README.md
+++ b/Cornerstone/README.md
@@ -23,3 +23,6 @@ To fully understand how to use this example, you must:
     * You can find the list of available parameters on an endpoint information page such as [this one](https://apiexplorer.csod.com/apiconnectorweb/apiexplorer#/apidoc/59aa5211-b2c9-45af-97b1-0c0902dc4060).
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Cornerstone API documentation](https://apiexplorer.csod.com/apiconnectorweb/apiexplorer#/info)

--- a/Discourse/README.md
+++ b/Discourse/README.md
@@ -15,6 +15,7 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Discourse/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Reference
 [Discourse API documentation](https://docs.discourse.org/)

--- a/Discourse/README.md
+++ b/Discourse/README.md
@@ -15,3 +15,6 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Discourse/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Discourse API documentation](https://docs.discourse.org/)

--- a/Discourse/README.md
+++ b/Discourse/README.md
@@ -15,7 +15,7 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Discourse/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-6. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+6. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Discourse API documentation](https://docs.discourse.org/)

--- a/Docebo LMS/README.md
+++ b/Docebo LMS/README.md
@@ -17,6 +17,7 @@ To fully understand how to use this example, you must:
 5. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Docebo%20LMS/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses two endpoints to retrieve courses and learning plans. The course endpoint uses a subquery to get course content. Adjust the configuration example to your own needs.
 6. Make sure you've changed all placeholders in the configuration with your own values.
 7. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+8. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Reference
 [Docebo LMS API documentation](https://help.docebo.com/hc/en-us)

--- a/Docebo LMS/README.md
+++ b/Docebo LMS/README.md
@@ -17,3 +17,6 @@ To fully understand how to use this example, you must:
 5. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Docebo%20LMS/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses two endpoints to retrieve courses and learning plans. The course endpoint uses a subquery to get course content. Adjust the configuration example to your own needs.
 6. Make sure you've changed all placeholders in the configuration with your own values.
 7. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Docebo LMS API documentation](https://help.docebo.com/hc/en-us)

--- a/Docebo LMS/README.md
+++ b/Docebo LMS/README.md
@@ -17,7 +17,7 @@ To fully understand how to use this example, you must:
 5. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Docebo%20LMS/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses two endpoints to retrieve courses and learning plans. The course endpoint uses a subquery to get course content. Adjust the configuration example to your own needs.
 6. Make sure you've changed all placeholders in the configuration with your own values.
 7. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-8. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+8. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Docebo LMS API documentation](https://help.docebo.com/hc/en-us)

--- a/DynamoDB/README.md
+++ b/DynamoDB/README.md
@@ -14,3 +14,6 @@ In order to fully understand and use this example, you must:
 2. [Create and configure a Generic REST API source](https://docs.coveo.com/en/1896/) using the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/DynamoDB/SourceJSONConfig.json). Adjust the configuration example to your own needs.
 3. Make sure you've changed all placeholders in the configuration with your own values.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[DynamoDB API documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/Welcome.html)

--- a/DynamoDB/README.md
+++ b/DynamoDB/README.md
@@ -14,7 +14,7 @@ In order to fully understand and use this example, you must:
 2. [Create and configure a Generic REST API source](https://docs.coveo.com/en/1896/) using the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/DynamoDB/SourceJSONConfig.json). Adjust the configuration example to your own needs.
 3. Make sure you've changed all placeholders in the configuration with your own values.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+5. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [DynamoDB API documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/Welcome.html)

--- a/DynamoDB/README.md
+++ b/DynamoDB/README.md
@@ -14,6 +14,7 @@ In order to fully understand and use this example, you must:
 2. [Create and configure a Generic REST API source](https://docs.coveo.com/en/1896/) using the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/DynamoDB/SourceJSONConfig.json). Adjust the configuration example to your own needs.
 3. Make sure you've changed all placeholders in the configuration with your own values.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 ## Reference
 [DynamoDB API documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/Welcome.html)

--- a/Exchange Online/README.md
+++ b/Exchange Online/README.md
@@ -17,3 +17,6 @@ To fully understand how to use this example, you must:
 5. Use the example in [`ExchangeOnlineSourceConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Exchange%20Online/ExchangeOnlineSourceConfig.json) as a base to build your source JSON configuration. This example uses OAuth 2.0 authentication. It also contains one Endpoint, which gets all emails of a given mailbox, and one Subquery, which gets email attachments. Adjust it to your own needs.
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[API documentation](https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/office-365-rest-apis-for-mail-calendars-and-contacts)

--- a/Exchange Online/README.md
+++ b/Exchange Online/README.md
@@ -17,6 +17,7 @@ To fully understand how to use this example, you must:
 5. Use the example in [`ExchangeOnlineSourceConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Exchange%20Online/ExchangeOnlineSourceConfig.json) as a base to build your source JSON configuration. This example uses OAuth 2.0 authentication. It also contains one Endpoint, which gets all emails of a given mailbox, and one Subquery, which gets email attachments. Adjust it to your own needs.
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+9. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [API documentation](https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/office-365-rest-apis-for-mail-calendars-and-contacts)

--- a/Github/README.md
+++ b/Github/README.md
@@ -15,6 +15,7 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Github/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [GitHub REST API documentation](https://docs.github.com/en/rest)

--- a/Github/README.md
+++ b/Github/README.md
@@ -16,5 +16,5 @@ To fully understand how to use this example, you must:
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 
-## Further Reading
-[GitHub REST API v3](https://developer.github.com/v3/)
+## Reference
+[GitHub REST API documentation](https://docs.github.com/en/rest)

--- a/Google Sheets/README.md
+++ b/Google Sheets/README.md
@@ -23,3 +23,6 @@ To fully understand how to use this example, you must:
 6. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Google%20Sheets/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust the configuration example to your own needs.
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Google Sheets API documentation](https://developers.google.com/sheets/api)

--- a/Google Sheets/README.md
+++ b/Google Sheets/README.md
@@ -23,6 +23,7 @@ To fully understand how to use this example, you must:
 6. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Google%20Sheets/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust the configuration example to your own needs.
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+9. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Google Sheets API documentation](https://developers.google.com/sheets/api)

--- a/LearnUpon/README.md
+++ b/LearnUpon/README.md
@@ -1,4 +1,4 @@
-# Indexing Discourse Using the Generic REST API Connector
+# Indexing LearnUpon Using the Generic REST API Connector
 
 ## Use Case
 This example shows how to retrieve courses from the LearnUpon platform. It is also possible to retrieve modules but this is not covered in this version.
@@ -17,4 +17,4 @@ To fully understand how to use this example, you must:
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 
 ## Reference
-[Discourse API documentation](https://docs.discourse.org/)
+[LearnUpon API documentation](https://docs.learnupon.com/api/#learnupon-technical-documentation)

--- a/LearnUpon/README.md
+++ b/LearnUpon/README.md
@@ -15,3 +15,6 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/LearnUpon/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Discourse API documentation](https://docs.discourse.org/)

--- a/LearnUpon/README.md
+++ b/LearnUpon/README.md
@@ -15,6 +15,7 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/LearnUpon/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [LearnUpon API documentation](https://docs.learnupon.com/api/#learnupon-technical-documentation)

--- a/LinkedIn Learning/README.md
+++ b/LinkedIn Learning/README.md
@@ -16,6 +16,7 @@ In order to fully understand how to use this example, you must:
 4. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/LinkedIn%20Learning/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust the configuration example to your own needs.
 5. Make sure you've changed all placeholders in the configuration with your own values.
 6. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+7. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [LinkedIn Learning API documentation](https://docs.microsoft.com/en-us/linkedin/learning/overview/)

--- a/LinkedIn Learning/README.md
+++ b/LinkedIn Learning/README.md
@@ -16,3 +16,6 @@ In order to fully understand how to use this example, you must:
 4. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/LinkedIn%20Learning/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust the configuration example to your own needs.
 5. Make sure you've changed all placeholders in the configuration with your own values.
 6. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[LinkedIn Learning API documentation](https://docs.microsoft.com/en-us/linkedin/learning/overview/)

--- a/Mindtickle/README.md
+++ b/Mindtickle/README.md
@@ -16,3 +16,4 @@ In MindTickle, course material is organized into three object types: SeriesColle
 2. Make sure you've changed all placeholders in the configuration with your own values.
 3. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 4. To reject non-Module items, [write an indexing pipeline extension]({{ site.baseurl }}/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/Mindtickle/IPE.py).
+5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.

--- a/Mindtickle/README.md
+++ b/Mindtickle/README.md
@@ -16,4 +16,4 @@ In MindTickle, course material is organized into three object types: SeriesColle
 2. Make sure you've changed all placeholders in the configuration with your own values.
 3. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 4. To reject non-Module items, [write an indexing pipeline extension](https://docs.coveo.com/en/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/Mindtickle/IPE.py).
-5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+5. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.

--- a/Mindtickle/README.md
+++ b/Mindtickle/README.md
@@ -15,5 +15,5 @@ In MindTickle, course material is organized into three object types: SeriesColle
 1. [Create and configure a Generic REST API source](https://docs.coveo.com/en/1896/) using the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Mindtickle/SourceJSONConfig.json). This JSON configuration indexes SeriesCollections through the main endpoint, and then SeriesModules as SeriesCollection subitems, and then Modules as subitems of the SeriesModules. Adjust the configuration example to your own needs.
 2. Make sure you've changed all placeholders in the configuration with your own values.
 3. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-4. To reject non-Module items, [write an indexing pipeline extension]({{ site.baseurl }}/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/Mindtickle/IPE.py).
+4. To reject non-Module items, [write an indexing pipeline extension](https://docs.coveo.com/en/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/Mindtickle/IPE.py).
 5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.

--- a/Moxie KB/README.md
+++ b/Moxie KB/README.md
@@ -24,4 +24,4 @@ You will need to make the four follwing API calls. If you need to test them, you
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 6. [Write an indexing pipeline extension](https://docs.coveo.com/en/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/Moxie%20KB/IPE.py).
-5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+5. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.

--- a/Moxie KB/README.md
+++ b/Moxie KB/README.md
@@ -23,3 +23,5 @@ You will need to make the four follwing API calls. If you need to test them, you
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/commit/fd92a6cd8e2afd6885d6360276cb1d5bc65abe6b) as a base to build your source JSON configuration. This example retrieves the list of articles using the main endpoint, then the body using a subquery, and then metadata using another subquery. Adjust the configuration example to your own needs. 
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. [Write an indexing pipeline extension](https://docs.coveo.com/en/1645/) based on the example in [`IPE.py`](https://github.com/coveooss/connectivity-library/blob/master/Moxie%20KB/IPE.py).
+5. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.

--- a/Pendo Feedback/README.md
+++ b/Pendo Feedback/README.md
@@ -15,6 +15,7 @@ To fully understand how to use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Pendo%20Feedback/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Pendo Feedback API Specifics
 * [API Documentation](http://apidoc.receptive.io/)

--- a/Pendo Feedback/README.md
+++ b/Pendo Feedback/README.md
@@ -107,3 +107,6 @@ You can use the sub query if you need additional data from Features, just add th
     "uploads": []
 }
 ```
+
+## Reference
+[Pendo Feedback API documentation](https://developers.pendo.io/docs/?bash#)

--- a/Skilljar LMS/README.md
+++ b/Skilljar LMS/README.md
@@ -19,6 +19,7 @@ The two typical objects that get indexed are:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Skilljar%20LMS/SourceJSONConfig.json) as a base to build your source JSON configuration. This example retrieves the list of published courses with the first endpoint, the course description using a subquery in the first endpoint, and the course series with the second endpoint. Adjust the configuration example to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 * [Getting started with the Skilljar API](http://support.skilljar.com/hc/en-us/articles/203811260-Getting-started-with-the-Skilljar-API)

--- a/Skilljar LMS/README.md
+++ b/Skilljar LMS/README.md
@@ -20,6 +20,6 @@ The two typical objects that get indexed are:
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 
-## Further Reading
+## Reference
 * [Getting started with the Skilljar API](http://support.skilljar.com/hc/en-us/articles/203811260-Getting-started-with-the-Skilljar-API)
 * [Skilljar API Endpoint Reference](https://api.skilljar.com/docs/#!/domains)

--- a/Slack/README.md
+++ b/Slack/README.md
@@ -35,7 +35,7 @@ A more practical use case for indexing Slack messages would be to index only the
 * Index pinned messages: when querying for the channel messages, index only the messages that have the `pinned_to` key in the JSON.
 * Index and group threads: thread replies are of "subtype" `thread_broadcast` and have the parent message ID under `root.client_msg_id`.
 
-## Further Reading
+## Reference
 * [Legacy token](https://get.slack.help/hc/en-us/articles/215770388-Create-and-regenerate-API-tokens#-internal-app-tokens)
 * [OAuth](https://api.slack.com/docs/oauth)
 * [API](https://api.slack.com/methods/conversations.history)

--- a/Slack/README.md
+++ b/Slack/README.md
@@ -30,6 +30,7 @@ A more practical use case for indexing Slack messages would be to index only the
 6. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Slack/SourceJSONConfig.json) as a base to build your source JSON configuration. This example has one endpoint to get the Slack channels, which includes a subquery to get the messages in each channel, and another endpoint to get the members. Adjust the configuration example to your own needs.
 7. Make sure you've changed all placeholders in the configuration with your own values.
 8. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+9. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ### Alternative Options
 * Index pinned messages: when querying for the channel messages, index only the messages that have the `pinned_to` key in the JSON.

--- a/Spigit/README.md
+++ b/Spigit/README.md
@@ -21,3 +21,4 @@ To fully understand and use this example, you must:
 4. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Spigit/SourceJSONConfig.json) as a base to build your source JSON configuration. This example has one endpoint to get the Slack channels, which includes a subquery to get the messages in each channel, and another endpoint to get the members. Adjust the configuration example to your own needs.
 5. Make sure you've changed all placeholders in the configuration with your own values.
 6. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+7. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.

--- a/Stackoverflow/README.md
+++ b/Stackoverflow/README.md
@@ -15,3 +15,6 @@ To fully understand and use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Stackoverflow/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses the main endpoint to get the questions and retrieves the answers as subitems. The main endpoint targets questions with the tags specified in the query parameters. Adjust the configuration example to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Stack Overflow API documentation](https://api.stackexchange.com/docs)

--- a/Stackoverflow/README.md
+++ b/Stackoverflow/README.md
@@ -15,6 +15,7 @@ To fully understand and use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Stackoverflow/SourceJSONConfig.json) as a base to build your source JSON configuration. This example uses the main endpoint to get the questions and retrieves the answers as subitems. The main endpoint targets questions with the tags specified in the query parameters. Adjust the configuration example to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Stack Overflow API documentation](https://api.stackexchange.com/docs)

--- a/UserVoice/README.md
+++ b/UserVoice/README.md
@@ -15,6 +15,7 @@ To fully understand and use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/UserVoice/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust the configuration example to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Getting Started with the UserVoice Admin API](https://developer.uservoice.com/docs/api/v2/getting-started/)

--- a/UserVoice/README.md
+++ b/UserVoice/README.md
@@ -16,5 +16,5 @@ To fully understand and use this example, you must:
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 
-## Further Reading
+## Reference
 [Getting Started with the UserVoice Admin API](https://developer.uservoice.com/docs/api/v2/getting-started/)

--- a/Vidyard/README.md
+++ b/Vidyard/README.md
@@ -14,6 +14,7 @@ To fully understand how to use this example, you must:
 2. [Create a Generic REST API](https://docs.coveo.com/en/1896/) source and, in the **Authorization** section, fill in you username and the API Token obtained in step 1. as the password.
 3. Use the example in [`SourceJSONConfig.json`](SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs. 
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+5. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Vidyard API documentation](https://developer.vidyard.com/)

--- a/Vidyard/README.md
+++ b/Vidyard/README.md
@@ -14,3 +14,6 @@ To fully understand how to use this example, you must:
 2. [Create a Generic REST API](https://docs.coveo.com/en/1896/) source and, in the **Authorization** section, fill in you username and the API Token obtained in step 1. as the password.
 3. Use the example in [`SourceJSONConfig.json`](SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs. 
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Vidyard API documentation](https://developer.vidyard.com/)

--- a/Vimeo/README.md
+++ b/Vimeo/README.md
@@ -15,6 +15,7 @@ To fully understand and use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Vimeo/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust the configuration example to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+6. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Vimeo API documentation](https://developer.vimeo.com/api/guides/start)

--- a/Vimeo/README.md
+++ b/Vimeo/README.md
@@ -15,3 +15,6 @@ To fully understand and use this example, you must:
 3. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Vimeo/SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust the configuration example to your own needs.
 4. Make sure you've changed all placeholders in the configuration with your own values.
 5. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Vimeo API documentation](https://developer.vimeo.com/api/guides/start)

--- a/Wistia/README.md
+++ b/Wistia/README.md
@@ -14,3 +14,6 @@ To fully understand how to use this example, you must:
 2. [Create a Generic REST API](https://docs.coveo.com/en/1896/) source and, in the **Authorization** section, fill in you username and the API key obtained in step 1. as the password.
 3. Use the example in [`SourceJSONConfig.json`](SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs. Wistia maintains a parent/child relationship between Project and Media objects, this leads to a single endpoint to index projects along with SubItem queries to indexed the related media objects.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+
+## Reference
+[Wistia API documentation](https://wistia.com/support/developers/data-api)

--- a/Wistia/README.md
+++ b/Wistia/README.md
@@ -14,6 +14,7 @@ To fully understand how to use this example, you must:
 2. [Create a Generic REST API](https://docs.coveo.com/en/1896/) source and, in the **Authorization** section, fill in you username and the API key obtained in step 1. as the password.
 3. Use the example in [`SourceJSONConfig.json`](SourceJSONConfig.json) as a base to build your source JSON configuration. Adjust it to your own needs. Wistia maintains a parent/child relationship between Project and Media objects, this leads to a single endpoint to index projects along with SubItem queries to indexed the related media objects.
 4. [Create the appropiate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+5. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 ## Reference
 [Wistia API documentation](https://wistia.com/support/developers/data-api)

--- a/WorkplaceByFacebook/readme.md
+++ b/WorkplaceByFacebook/readme.md
@@ -14,32 +14,21 @@ To fully understand how to use this example, you must:
 2. Make sure the Integration has the following access: Read group content, Read user timeline, Read user email, Read group membership, Read all messages, Create link previews, Read work profile, Manage Knowledge Library content, and Manage work profiles.
 3. Activate the Feature Flag: `Generic rest permissions config`.
 4. To index your Workplace by Facebook content, you will need to [create three Generic REST API sources](https://docs.coveo.com/en/1896/): one for the content that supports incremental indexing, two for the content that does not support incremental indexing. For each source you create, follow steps 4 to 7.
-
 5. In the **Authentication** section, enter your Workplace by Facebook access token under **API key authentication**.
-
 6. In the **Content to include** section, paste one of the following configurations:
-
     - For your first non incremental indexing source, enter the [NormalConfig.json](https://github.com/coveooss/connectivity-library/blob/master/WorkplaceByFacebook/index/NormalConfig.json) configuration.
-
     - For your second incremental indexing source, enter the [MembersInfoConfig.json](https://github.com/coveooss/connectivity-library/blob/master/WorkplaceByFacebook/index/MembersInfoConfig.json) configuration.
-
     - For the incremental indexing source, enter the [IncrementalConfig.json](https://github.com/coveooss/connectivity-library/blob/master/WorkplaceByFacebook/index/IncrementalConfig.json) configuration.
-
-6. (Optional) After saving the source, and you forgot to change the security setting: Now change the `createSecurityProvider.py` script.
+6. (Optional) After saving the source, and you forgot to change the security setting: Now change the [createSecurityProvider.py](https://github.com/coveooss/connectivity-library/blob/master/WorkplaceByFacebook/createSecurityProvider.py) script.
    - Change the `organizationId`, `sourceId` and the `authToken`.
    - Execute the script. This will create a security provider for your source.
-
 7. Add the [SecurityConfig.json](https://github.com/coveooss/connectivity-library/blob/master/WorkplaceByFacebook/index/SecurityConfig.json) security configuration to the JSON configuration you provided at step 5. 
-
 8. Ensure you've replaced all placeholders (e.g., `solutions788` in the URIs) in the configuration with your own values.
-
 9. Once you've create all three sources, [schedule a refresh operation](https://docs.coveo.com/en/1933/) every 10 minutes for your incremental indexing source.
-
 10. [Add](https://docs.coveo.com/en/1645/) the [FixFacebookURL.py](https://github.com/coveooss/connectivity-library/blob/master/WorkplaceByFacebook/FixFacebookURL.py) indexing pipeline extension to your organization.
-
 11. [Apply this extension](https://docs.coveo.com/en/1936/) to your incremental indexing source.
-
 12. [Create the appropriate fields and mappings](https://docs.coveo.com/en/1896/#completion).
+13. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
 
 
 ## Content indexed

--- a/WorkplaceByFacebook/readme.md
+++ b/WorkplaceByFacebook/readme.md
@@ -28,7 +28,7 @@ To fully understand how to use this example, you must:
 10. [Add](https://docs.coveo.com/en/1645/) the [FixFacebookURL.py](https://github.com/coveooss/connectivity-library/blob/master/WorkplaceByFacebook/FixFacebookURL.py) indexing pipeline extension to your organization.
 11. [Apply this extension](https://docs.coveo.com/en/1936/) to your incremental indexing source.
 12. [Create the appropriate fields and mappings](https://docs.coveo.com/en/1896/#completion).
-13. When testing your source configuration, you might also find you need extra configurations such as an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to index the desired content properly.
+13. Check whether your source indexes the desired content properly. You might find you need an additional [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 
 
 ## Content indexed

--- a/WorkplaceByFacebook/readme.md
+++ b/WorkplaceByFacebook/readme.md
@@ -88,16 +88,11 @@ Nested community groups are not supported
 Posts can contain a message and/or a story. The field `mymessage` and/or `mystory` is added to the content. `message` is a better fit, so if that is there, use that one.
 
 ## Reference
-https://developers.facebook.com/docs/workplace/custom-integrations-new/
-
-https://developers.facebook.com/docs/workplace/reference
-
-https://developers.facebook.com/docs/graph-api/using-graph-api
-
-https://github.com/fbsamples/workplace-platform-samples/tree/master/SampleAPIEndpoints/Postman
-
-https://developers.facebook.com/docs/workplace/reference/graph-api/community
-
+* [Meta for Developers: Custom Integrations](https://developers.facebook.com/docs/workplace/custom-integrations-new/)
+* [Meta for Developers: Reference](https://developers.facebook.com/docs/workplace/reference)
+* [Meta for Developers: Graph API Overview](https://developers.facebook.com/docs/graph-api/using-graph-api)
+* [Meta for Developers: Graph API Community](https://developers.facebook.com/docs/workplace/reference/graph-api/community)
+* [GitHub: Workplace From Facebook Platform API samples for Postman](https://github.com/fbsamples/workplace-platform-samples/tree/master/SampleAPIEndpoints/Postman)
 
 ## Version
 1.0 Feb 2021, Wim Nijmeijer


### PR DESCRIPTION
Two sections of Coveo's public doc are being refactored for easier maintenance and greater scalability ([Connector Directory](https://docs.coveo.com/en/1702/index-content/connector-directory#other-indexable-repositories) and [Connectivity Library](https://docs.coveo.com/en/1996/index-content/generic-rest-api-source-json-configuration-examples#open-source-connectivity-library)).

This PR transfers the info appearing in the [Connectivity Library](https://docs.coveo.com/en/1996/index-content/generic-rest-api-source-json-configuration-examples#open-source-connectivity-library) section to this repo. The changes are mainly:
- If the GitHub folder contains an IPE (python file), add a step instructing readers to add the IPE to their org.
- Add a step instructing readers to check the indexed content and, if needed, write an IPE to achieve the desired result.
- Add a reference section with links to the app API documentation.