### PR TITLE
[DOC-12689] Fix README for Sitecore Content Hub

### DIFF
--- a/Sitecore Content Hub/README.md
+++ b/Sitecore Content Hub/README.md
@@ -17,7 +17,7 @@ To fully understand how to use this example, you must:
     2. Under **Content to Include**, enter your source JSON configuration. Use the example in [`SourceJSONConfig.json`](https://github.com/coveooss/connectivity-library/blob/master/Sitecore%20Content%20Hub/SourceJSONConfig.json) as a base.
     3. Make sure you've changed all placeholders in the configuration with your own values:
         1. Replace the URL placeholders with your site's URL.
-    4. Add or update the `Endpoints` section according to your data structure in Contentstack.
+    4. Add or update the `Endpoints` section according to your data structure in Sitecore Content Hub.
 4. [Create the appropriate fields and mappings](https://docs.coveo.com/en/1896/#completion).
 5. Check whether your source indexes the desired content properly. You might find you need an [indexing pipeline extension](https://docs.coveo.com/en/1645/) to achieve the expected result.
 


### PR DESCRIPTION
[DOC-12689]

Proposed changes:
- Fixing README for Sitecore Content Hub instead of Contentstack

[DOC-12689]: https://coveord.atlassian.net/browse/DOC-12689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ